### PR TITLE
fix stage img in yml

### DIFF
--- a/Stage2/healthcheck.yml
+++ b/Stage2/healthcheck.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: hw-demo-container
-          image: "registry.ng.bluemix.net/<namespace>/health-check-demo"
+          image: "registry.ng.bluemix.net/<namespace>/hello-world:2"
           imagePullPolicy: Always
           livenessProbe:
             httpGet:


### PR DESCRIPTION
This fix is necessary to run successfully the stage 2 of the tutorial in the doc. Otherwise updating the namespace is not enough and pulling the image will fail.