### PR TITLE
Added TravisCI integration to the Demo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: script
 
 env:
   global:
-     CF_TARGET_URL="https://api.ng.bluemix.net"
+     CF_TARGET_URL="https://api.stage1.ng.bluemix.net"
 
 script: bash -n *.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: script
 
 env:
   global:
-     CF_TARGET_URL="https://api.stage1.ng.bluemix.net"
+     CF_TARGET_URL="https://api.ng.bluemix.net"
 
 script: bash -n *.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ deploy:
     skip_cleanup: true
     script: ./deploy_rollup.sh
     on:
+      tags: true
       all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: script
 
+sudo: required
+
 env:
   global:
      CF_TARGET_URL="https://api.ng.bluemix.net"
+
+services:
+  - docker
 
 script: bash -n *.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: script
+
+env:
+  global:
+     CF_TARGET_URL="https://api.ng.bluemix.net"
+
+script: bash -n *.sh
+
+ß
+deploy:
+  - provider: script
+    skip_cleanup: true
+    script: ./deploy_rollup.sh
+    on:
+      branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: script
 
-sudo: required
-
 env:
   global:
      CF_TARGET_URL="https://api.ng.bluemix.net"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,4 @@ deploy:
     skip_cleanup: true
     script: ./deploy_rollup.sh
     on:
-      tags: true
       all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: script
 
 env:
   global:
-     CF_TARGET_URL="https://api.stage1.ng.bluemix.net"
+     CF_TARGET_URL="https://api.ng.bluemix.net"
 
 script: bash -n *.sh
 
-ß
+
 deploy:
   - provider: script
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ deploy:
     skip_cleanup: true
     script: ./deploy_rollup.sh
     on:
-      branch: master
+      all_branches: true

--- a/Stage3/README.md
+++ b/Stage3/README.md
@@ -41,13 +41,13 @@ In `watson-deployment.yml`, update the image tag with the registry path to the i
     spec:
       containers:
         - name: watson
-          image: "registry.ng.bluemix.net/contbot/watson" # change to the path of the watson image you just pushed.
+          image: "registry.ng.bluemix.net/<namespace>/watson" # change to the path of the watson image you just pushed.
                                                           # ex: image: "registry.ng.bluemix.net/<namespace>/watson"
 ...
     spec:
       containers:
-        - name: watson
-          image: "registry.ng.bluemix.net/contbot/watson-talk" # change to the path of the watson-talk image you just pushed.
+        - name: watson-talk
+          image: "registry.ng.bluemix.net/<namespace>/watson-talk" # change to the path of the watson-talk image you just pushed.
                                                                # ex: image: "registry.ng.bluemix.net/<namespace>/watson-talk"
 ```
 

--- a/Stage3/README.md
+++ b/Stage3/README.md
@@ -41,14 +41,14 @@ In `watson-deployment.yml`, update the image tag with the registry path to the i
     spec:
       containers:
         - name: watson
-          image: "registry.ng.bluemix.net/<namespace>/watson" # change to the path of the watson image
-                                                                     #  you just pushed to the registry...
+          image: "registry.ng.bluemix.net/contbot/watson" # change to the path of the watson image you just pushed.
+                                                          # ex: image: "registry.ng.bluemix.net/<namespace>/watson"
 ...
     spec:
       containers:
         - name: watson
-          image: "registry.ng.bluemix.net/<namespace>/watson-talk" # change to the path of the watson-talk image
-                                                                     #  you just pushed to the registry...
+          image: "registry.ng.bluemix.net/contbot/watson-talk" # change to the path of the watson-talk image you just pushed.
+                                                               # ex: image: "registry.ng.bluemix.net/<namespace>/watson-talk"
 ```
 
 

--- a/Stage3/README.md
+++ b/Stage3/README.md
@@ -50,7 +50,8 @@ In `watson-deployment.yml`, update the image tag with the registry path to the i
           image: "registry.ng.bluemix.net/<namespace>/watson-talk" # change to the path of the watson-talk image
                                                                      #  you just pushed to the registry...
 ```
-Note that by default, the image path is set to the staging endpoint for the IBM image registry. Change this to the public registry by removing `stage1` from the image path in the deployment yaml.
+
+
 # Create a bluemix service via the cli
 
 In order to begin using the watson tone analyzer (the bluemix service this application), we must first request an instance of the analyzer in the org and space we have set up our cluster in. If you need to check what space and org you are currently using, simply run `bx login` and select the space and org you were using for stage 1 and 2 of the lab.

--- a/Stage3/README.md
+++ b/Stage3/README.md
@@ -50,7 +50,7 @@ In `watson-deployment.yml`, update the image tag with the registry path to the i
           image: "registry.ng.bluemix.net/<namespace>/watson-talk" # change to the path of the watson-talk image
                                                                      #  you just pushed to the registry...
 ```
-
+Note that by default, the image path is set to the staging endpoint for the IBM image registry. Change this to the public registry by removing `stage1` from the image path in the deployment yaml.
 # Create a bluemix service via the cli
 
 In order to begin using the watson tone analyzer (the bluemix service this application), we must first request an instance of the analyzer in the org and space we have set up our cluster in. If you need to check what space and org you are currently using, simply run `bx login` and select the space and org you were using for stage 1 and 2 of the lab.

--- a/Stage3/watson-deployment.yml
+++ b/Stage3/watson-deployment.yml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: watson
-          image: "registry.ng.bluemix.net/cjackso/watson" # edit here!
+          image: "registry.ng.bluemix.net/<namespace>/watson" # edit here!
           imagePullPolicy: Always
           volumeMounts:
             - mountPath: /opt/service-bind
@@ -52,7 +52,7 @@ spec:
     spec:
       containers:
         - name: watson-talk
-          image: "registry.ng.bluemix.net/cjackso/watson-talk" # edit here!
+          image: "registry.ng.bluemix.net/<namespace>/watson-talk" # edit here!
           imagePullPolicy: Always
 ---
 apiVersion: v1

--- a/Stage3/watson-deployment.yml
+++ b/Stage3/watson-deployment.yml
@@ -12,8 +12,8 @@ spec:
     spec:
       containers:
         - name: watson
-          image: "registry.ng.bluemix.net/<namespace>/watson"
-          imagePullPolicy: IfNotPresent
+          image: "registry.stage1.ng.bluemix.net/cjackso/watson" # edit here!
+          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /opt/service-bind
               name: service-bind-volume
@@ -52,8 +52,8 @@ spec:
     spec:
       containers:
         - name: watson-talk
-          image: "registry.ng.bluemix.net/<namespace>/watson-talk"
-          imagePullPolicy: IfNotPresent
+          image: "registry.stage1.ng.bluemix.net/cjackso/watson-talk" # edit here!
+          imagePullPolicy: Always
 ---
 apiVersion: v1
 kind: Service

--- a/Stage3/watson-deployment.yml
+++ b/Stage3/watson-deployment.yml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: watson
-          image: "registry.stage1.ng.bluemix.net/cjackso/watson" # edit here!
+          image: "registry.ng.bluemix.net/cjackso/watson" # edit here!
           imagePullPolicy: Always
           volumeMounts:
             - mountPath: /opt/service-bind
@@ -52,7 +52,7 @@ spec:
     spec:
       containers:
         - name: watson-talk
-          image: "registry.stage1.ng.bluemix.net/cjackso/watson-talk" # edit here!
+          image: "registry.ng.bluemix.net/cjackso/watson-talk" # edit here!
           imagePullPolicy: Always
 ---
 apiVersion: v1

--- a/bx_login.sh
+++ b/bx_login.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+if [ -z $CF_ORG ]; then
+  CF_ORG="$BLUEMIX_ORG"
+fi
+if [ -z $CF_SPACE ]; then
+  CF_SPACE="$BLUEMIX_SPACE"
+fi
+
+
+if [ -z "$BLUEMIX_USER" ] || [ -z "$BLUEMIX_PASSWORD" ] || [ -z "$BLUEMIX_ACCOUNT" ]; then
+  echo "Define all required environment variables and rerun the stage."
+  exit 1
+fi
+echo "Deploy pods"
+
+echo "bx login -a $CF_TARGET_URL"
+bx login -a "$CF_TARGET_URL" -u "$BLUEMIX_USER" -p "$BLUEMIX_PASSWORD" -c "$BLUEMIX_ACCOUNT" -o "$CF_ORG" -s "$CF_SPACE"
+if [ $? -ne 0 ]; then
+  echo "Failed to authenticate to Bluemix"
+  exit 1
+fi
+
+# Init container clusters
+echo "bx cs init"
+bx cs init
+if [ $? -ne 0 ]; then
+  echo "Failed to initialize to Bluemix Container Service"
+  exit 1
+fi

--- a/bx_login.sh
+++ b/bx_login.sh
@@ -28,3 +28,11 @@ if [ $? -ne 0 ]; then
   echo "Failed to initialize to Bluemix Container Service"
   exit 1
 fi
+
+# Init container registry
+echo "bx cr login"
+bx cr login
+if [ $? -ne 0 ]; then
+  echo "Failed to login to the Bluemix Container Registry"
+  exit 1
+fi

--- a/bx_login.sh
+++ b/bx_login.sh
@@ -8,7 +8,7 @@ if [ -z $CF_SPACE ]; then
 fi
 
 
-if [ -z "$BLUEMIX_USER" ] || [ -z "$BLUEMIX_PASSWORD" ] || [ -z "$BLUEMIX_ACCOUNT" ]; then
+if [ -z "$BLUEMIX_USER" ] || [ -z "$BLUEMIX_PASSWORD" ] || [ -z "$BLUEMIX_ACCOUNT" ] || [ -z "$BLUEMIX_NAMESPACE" ]; then
   echo "Define all required environment variables and rerun the stage."
   exit 1
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+echo "Create Guestbook"
+IP_ADDR=$(bx cs workers $CLUSTER_NAME | grep normal | awk '{ print $2 }')
+if [ -z $IP_ADDR ]; then
+  echo "$CLUSTER_NAME not created or workers not ready"
+  exit 1
+fi
+
+echo -e "Configuring vars"
+exp=$(bx cs cluster-config $CLUSTER_NAME | grep export)
+if [ $? -ne 0 ]; then
+  echo "Cluster $CLUSTER_NAME not created or not ready."
+  exit 1
+fi
+eval "$exp"
+
+echo -e "Downloading guestbook yml"
+curl --silent "https://raw.githubusercontent.com/kubernetes/kubernetes/master/examples/guestbook/all-in-one/guestbook-all-in-one.yaml" > guestbook.yml
+
+#Find the line that has the comment about the load balancer and add the nodeport def after this
+let NU=$(awk '/^  # type: LoadBalancer/{ print NR; exit }' guestbook.yml)+3
+NU=$NU\i
+sed -i "$NU\ \ type: NodePort" guestbook.yml #For OSX: brew install gnu-sed; replace sed references with gsed
+
+echo -e "Deleting previous version of guestbook if it exists"
+kubectl delete --ignore-not-found=true   -f guestbook.yml
+
+echo -e "Creating pods"
+kubectl create -f guestbook.yml
+
+PORT=$(kubectl get services | grep frontend | sed 's/.*:\([0-9]*\).*/\1/g')
+
+echo ""
+echo "View the guestbook at http://$IP_ADDR:$PORT"

--- a/deploy.sh
+++ b/deploy.sh
@@ -69,6 +69,8 @@ if [ $? -ne 0]; then
   exit 1
 fi
 
+sed -i "s/<namespace>/${BLUEMIX_NAMESPACE}/" watson-deployment.yml
+
 echo -e "Creating pods"
 kubectl create -f watson-deployment.yml
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -36,7 +36,7 @@ if [ $? -eq 0 ]; then
 fi
 
 echo -e "Deleting previous Watson Tone Analyzer instance if it exists"
-bx service delete tone
+bx service delete tone -f
 
 echo -e "Creating new instance of Watson Tone Analyzer named tone..."
 bx service create tone_analyzer standard tone

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "Create Guestbook"
+echo "Create Demo Application"
 IP_ADDR=$(bx cs workers $CLUSTER_NAME | grep normal | awk '{ print $2 }')
 if [ -z $IP_ADDR ]; then
   echo "$CLUSTER_NAME not created or workers not ready"
@@ -15,21 +15,21 @@ if [ $? -ne 0 ]; then
 fi
 eval "$exp"
 
-echo -e "Downloading guestbook yml"
-curl --silent "https://raw.githubusercontent.com/kubernetes/kubernetes/master/examples/guestbook/all-in-one/guestbook-all-in-one.yaml" > guestbook.yml
+echo -e "Downloading Stage 3 Watson Deployment yml"
+curl --silent "https://raw.githubusercontent.com/IBM/container-service-getting-started-wt/master/Stage3/watson-deployment.yml" > watson-deployment.yml
 
-#Find the line that has the comment about the load balancer and add the nodeport def after this
-let NU=$(awk '/^  # type: LoadBalancer/{ print NR; exit }' guestbook.yml)+3
-NU=$NU\i
-sed -i "$NU\ \ type: NodePort" guestbook.yml #For OSX: brew install gnu-sed; replace sed references with gsed
+# #Find the line that has the comment about the load balancer and add the nodeport def after this
+# let NU=$(awk '/^  # type: LoadBalancer/{ print NR; exit }' guestbook.yml)+3
+# NU=$NU\i
+# sed -i "$NU\ \ type: NodePort" guestbook.yml #For OSX: brew install gnu-sed; replace sed references with gsed
 
 echo -e "Deleting previous version of guestbook if it exists"
-kubectl delete --ignore-not-found=true   -f guestbook.yml
+kubectl delete --ignore-not-found=true   -f watson-deployment.yml
 
 echo -e "Creating pods"
 kubectl create -f guestbook.yml
 
-PORT=$(kubectl get services | grep frontend | sed 's/.*:\([0-9]*\).*/\1/g')
+PORT=$(kubectl get services | grep watson-service | sed 's/.*:\([0-9]*\).*/\1/g')
 
 echo ""
 echo "View the guestbook at http://$IP_ADDR:$PORT"

--- a/deploy.sh
+++ b/deploy.sh
@@ -28,6 +28,12 @@ cd Stage3/
 echo -e "Deleting previous version of Watson Deployment if it exists"
 kubectl delete --ignore-not-found=true -f watson-deployment.yml
 
+echo -e "Unbinding previous version of Watson Tone Analyzer if it exists"
+bx cs cluster-service-unbind $CLUSTER_NAME default tone
+
+echo -e "Binding Watson Tone Service to Cluster and Pod"
+bx cs cluster-service-bind $CLUSTER_NAME default tone
+
 echo -e "Creating pods"
 kubectl create -f watson-deployment.yml
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -15,21 +15,23 @@ if [ $? -ne 0 ]; then
 fi
 eval "$exp"
 
-echo -e "Downloading Stage 3 Watson Deployment yml"
-curl --silent "https://raw.githubusercontent.com/IBM/container-service-getting-started-wt/master/Stage3/watson-deployment.yml" > watson-deployment.yml
-
+echo -e "Setting up Stage 3 Watson Deployment yml"
+cd Stage3/
+# curl --silent "https://raw.githubusercontent.com/IBM/container-service-getting-started-wt/master/Stage3/watson-deployment.yml" > watson-deployment.yml
+#
+## WILL NEED FOR LOADBALANCER ###
 # #Find the line that has the comment about the load balancer and add the nodeport def after this
 # let NU=$(awk '/^  # type: LoadBalancer/{ print NR; exit }' guestbook.yml)+3
 # NU=$NU\i
 # sed -i "$NU\ \ type: NodePort" guestbook.yml #For OSX: brew install gnu-sed; replace sed references with gsed
 
-echo -e "Deleting previous version of guestbook if it exists"
-kubectl delete --ignore-not-found=true   -f watson-deployment.yml
+echo -e "Deleting previous version of Watson Deployment if it exists"
+kubectl delete --ignore-not-found=true -f watson-deployment.yml
 
 echo -e "Creating pods"
-kubectl create -f guestbook.yml
+kubectl create -f watson-deployment.yml
 
 PORT=$(kubectl get services | grep watson-service | sed 's/.*:\([0-9]*\).*/\1/g')
 
 echo ""
-echo "View the guestbook at http://$IP_ADDR:$PORT"
+echo "View the watson talk service at http://$IP_ADDR:$PORT"

--- a/deploy.sh
+++ b/deploy.sh
@@ -46,9 +46,10 @@ bx cs cluster-service-bind $CLUSTER_NAME default tone
 
 echo -e "Building Watson and Watson-talk images..."
 cd watson/
-docker build -t registry.ng.bluemix.net/contbot/watson .
+docker build -t registry.ng.bluemix.net/contbot/watson . &> buildout.txt
 if [ $? -ne 0 ]; then
   echo "Could not create the watson image for the build"
+  cat buildout.txt
   exit 1
 fi
 docker push registry.ng.bluemix.net/contbot/watson
@@ -58,9 +59,10 @@ if [ $? -ne 0 ]; then
 fi
 cd ..
 cd watson-talk/
-docker build -t registry.ng.bluemix.net/contbot/watson-talk .
+docker build -t registry.ng.bluemix.net/contbot/watson-talk . &> buildout.txt
 if [ $? -ne 0 ]; then
   echo "Could not create the watson-talk image for the build"
+  cat buildout.txt
   exit 1
 fi
 docker push registry.ng.bluemix.net/contbot/watson-talk
@@ -71,7 +73,7 @@ fi
 
 echo -e "Injecting image namespace into deployment yamls"
 cd ..
-sed -i "s/<namespace>/contbot/" watson-deployment.yml
+sed -i "s/<namespace>/${BLUEMIX_NAMESPACE}/" watson-deployment.yml
 if [ $? -ne 0 ] ; then
   echo "Could not inject image namespace into deployment yaml"
   exit 1

--- a/deploy.sh
+++ b/deploy.sh
@@ -71,7 +71,7 @@ fi
 
 echo -e "Injecting image namespace into deployment yamls"
 cd ..
-sed -i "s/<namespace>/contbot/" watson-deployment.yml
+sed -i "s/<namespace>/${BLUEMIX_NAMESPACE}/" watson-deployment.yml
 if [ $? -ne 0 ] ; then
   echo "Could not inject image namespace into deployment yaml"
   exit 1

--- a/deploy.sh
+++ b/deploy.sh
@@ -52,10 +52,10 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 docker push registry.ng.bluemix.net/contbot/watson
-if [ $? -ne 0]; then
+if [ $? -ne 0 ]; then
   echo "Could not push the watson image for the build"
   exit 1
-fi 
+fi
 cd ..
 cd watson-talk/
 docker build -t registry.ng.bluemix.net/contbot/watson-talk .
@@ -64,12 +64,18 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 docker push registry.ng.bluemix.net/contbot/watson-talk
-if [ $? -ne 0]; then
+if [ $? -ne 0 ] ; then
   echo "Could not push the watson image for the build"
   exit 1
 fi
 
+echo -e "Injecting image namespace into deployment yamls"
+cd ..
 sed -i "s/<namespace>/${BLUEMIX_NAMESPACE}/" watson-deployment.yml
+if [ $? -ne 0 ] ; then
+  echo "Could not inject image namespace into deployment yaml"
+  exit 1
+fi
 
 echo -e "Creating pods"
 kubectl create -f watson-deployment.yml

--- a/deploy.sh
+++ b/deploy.sh
@@ -71,7 +71,7 @@ fi
 
 echo -e "Injecting image namespace into deployment yamls"
 cd ..
-sed -i "s/<namespace>/${BLUEMIX_NAMESPACE}/" watson-deployment.yml
+sed -i "s/<namespace>/contbot/" watson-deployment.yml
 if [ $? -ne 0 ] ; then
   echo "Could not inject image namespace into deployment yaml"
   exit 1

--- a/deploy.sh
+++ b/deploy.sh
@@ -29,7 +29,10 @@ echo -e "Deleting previous version of Watson Deployment if it exists"
 kubectl delete --ignore-not-found=true -f watson-deployment.yml
 
 echo -e "Unbinding previous version of Watson Tone Analyzer if it exists"
-bx cs cluster-service-unbind $CLUSTER_NAME default tone
+bx service list | grep tone
+if [ $? -eq 0 ]; then
+  bx cs cluster-service-unbind $CLUSTER_NAME default tone
+fi
 
 echo -e "Binding Watson Tone Service to Cluster and Pod"
 bx cs cluster-service-bind $CLUSTER_NAME default tone

--- a/deploy_rollup.sh
+++ b/deploy_rollup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+echo "Install Bluemix CLI"
+. ./install_bx.sh
+if [ $? -ne 0 ]; then
+  echo "Failed to install Bluemix Container Service CLI prerequisites"
+  exit 1
+fi
+
+echo "Login to Bluemix"
+./bx_login.sh
+if [ $? -ne 0 ]; then
+  echo "Failed to authenticate to Bluemix Container Service"
+  exit 1
+fi
+
+echo "Deploy pods"
+./deploy.sh
+if [ $? -ne 0 ]; then
+  echo "Failed to Deploy pods to Bluemix Container Service"
+  exit 1
+fi

--- a/deploy_rollup.sh
+++ b/deploy_rollup.sh
@@ -13,6 +13,13 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+echo "Testing yml files for generalized namespace"
+./test_yml.sh
+if [ $? -ne 0 ]; then
+  echo "Failed to find <namespace> in deployment YAML files"
+  exit 1
+fi
+
 echo "Deploy pods for Stage 3..."
 ./deploy.sh
 if [ $? -ne 0 ]; then

--- a/deploy_rollup.sh
+++ b/deploy_rollup.sh
@@ -14,14 +14,14 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Testing yml files for generalized namespace"
-./test_yml.sh
+. ./test_yml.sh
 if [ $? -ne 0 ]; then
   echo "Failed to find <namespace> in deployment YAML files"
   exit 1
 fi
 
 echo "Deploy pods for Stage 3..."
-./deploy.sh
+. ./deploy.sh
 if [ $? -ne 0 ]; then
   echo "Failed to Deploy pods for stage 3 to Bluemix Container Service"
   exit 1

--- a/deploy_rollup.sh
+++ b/deploy_rollup.sh
@@ -7,7 +7,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Login to Bluemix"
-./bx_login.sh
+. ./bx_login.sh
 if [ $? -ne 0 ]; then
   echo "Failed to authenticate to Bluemix Container Service"
   exit 1

--- a/deploy_rollup.sh
+++ b/deploy_rollup.sh
@@ -13,9 +13,9 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-echo "Deploy pods"
+echo "Deploy pods for Stage 3..."
 ./deploy.sh
 if [ $? -ne 0 ]; then
-  echo "Failed to Deploy pods to Bluemix Container Service"
+  echo "Failed to Deploy pods for stage 3 to Bluemix Container Service"
   exit 1
 fi

--- a/install_bx.sh
+++ b/install_bx.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+echo "Download Bluemix CLI"
+wget --quiet --output-document=/tmp/Bluemix_CLI_amd64.tar.gz  http://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/latest/Bluemix_CLI_amd64.tar.gz
+tar -xf /tmp/Bluemix_CLI_amd64.tar.gz --directory=/tmp
+
+# Create bx alias
+echo "#!/bin/sh" >/tmp/Bluemix_CLI/bin/bx
+echo "/tmp/Bluemix_CLI/bin/bluemix \"\$@\" " >>/tmp/Bluemix_CLI/bin/bx
+chmod +x /tmp/Bluemix_CLI/bin/*
+
+export PATH="/tmp/Bluemix_CLI/bin:$PATH"
+
+# Install Armada CS plugin
+echo "Install the Bluemix container-service plugin"
+bx plugin install container-service -r Bluemix
+
+echo "Install kubectl"
+wget --quiet --output-document=/tmp/Bluemix_CLI/bin/kubectl  https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+chmod +x /tmp/Bluemix_CLI/bin/kubectl
+
+if [ -n "$DEBUG" ]; then
+  bx --version
+  bx plugin list
+fi

--- a/install_bx.sh
+++ b/install_bx.sh
@@ -15,6 +15,7 @@ export PATH="/tmp/Bluemix_CLI/bin:$PATH"
 # Install Armada CS plugin
 echo "Install the Bluemix container-service plugin"
 bx plugin install container-service -r Bluemix
+bx plugin install container-registry -r Bluemix
 
 echo "Install kubectl"
 wget --quiet --output-document=/tmp/Bluemix_CLI/bin/kubectl  https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl

--- a/install_bx.sh
+++ b/install_bx.sh
@@ -8,6 +8,7 @@ tar -xf /tmp/Bluemix_CLI_amd64.tar.gz --directory=/tmp
 echo "#!/bin/sh" >/tmp/Bluemix_CLI/bin/bx
 echo "/tmp/Bluemix_CLI/bin/bluemix \"\$@\" " >>/tmp/Bluemix_CLI/bin/bx
 chmod +x /tmp/Bluemix_CLI/bin/*
+chmod +x /tmp/Bluemix_CLI/bin/cfcli/*
 
 export PATH="/tmp/Bluemix_CLI/bin:$PATH"
 

--- a/test_yml.sh
+++ b/test_yml.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+echo "Testing YAML files for <namespace>"
+ls */*.yml
+imageLines=`grep image: */*.yml`
+namespaceLines=`grep \<namespace\> */*.yml`
+if [ "$imageLines" = "$namespaceLines" ]; then
+    echo "<namespace> found as expected in YAML files"
+else
+    echo "<namespace> NOT FOUND as expected in YAML files"
+    exit 1
+fi
+


### PR DESCRIPTION
With this Commit, we now ensure every new PR opened against the demo application master will have a CI Deploy test run against that commit. 

The test simply deploys stage 3 of the demo to start, will add further deployments of step 1 and 2 in the coming days. 

build breakdown:
travis.yml -> calls deploy_rollup.sh
deploy_rollup -> installs bx (install_bx.sh), logs into bluemix (bx_login.sh) and deploys the watson talk service (deploy.sh)