### PR TITLE
Fix for vulnerable packages

### DIFF
--- a/Stage1/Dockerfile
+++ b/Stage1/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.9.2
+FROM node:6
 COPY app.js .
 COPY package.json .
 RUN npm install

--- a/Stage1/package.json
+++ b/Stage1/package.json
@@ -4,6 +4,6 @@
   "version": "0.0.1",
   "description": "Basic hello world application for Node.js",
   "dependencies": {
-    "express": "3.4.8"
+    "express": "3.x"
   }
 }

--- a/Stage2/Dockerfile
+++ b/Stage2/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.9.2
+FROM node:6
 COPY app.js .
 COPY package.json .
 RUN npm install

--- a/Stage2/app.js
+++ b/Stage2/app.js
@@ -5,7 +5,7 @@ var startTime = Date.now()
 var delay = 10000 + Math.floor(Math.random() * 5000)
 
 app.get('/', function(req, res) {
-  res.send('Hello world! Great job getting the second stage up and running!')
+  res.send('Hello world! Great job getting the second stage up and running!\n')
 })
 app.get('/healthz', function(req, res) {
   if ((Date.now() - startTime) > delay) {

--- a/Stage2/package.json
+++ b/Stage2/package.json
@@ -4,6 +4,6 @@
   "version": "0.0.1",
   "description": "Basic hello world application for Node.js",
   "dependencies": {
-    "express": "3.4.8"
+    "express": "3.x"
   }
 }

--- a/Stage3/watson-talk/Dockerfile
+++ b/Stage3/watson-talk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.9.2
+FROM node:6
 COPY app.js .
 COPY package.json .
 RUN npm install

--- a/Stage3/watson-talk/package.json
+++ b/Stage3/watson-talk/package.json
@@ -2,7 +2,7 @@
   "name": "hello-world-armada",
   "private": false,
   "version": "0.0.1",
-  "description": "Basic Watson Tone relay application for Node.js",
+  "description": "Basic Watson Tone application for Node.js",
   "dependencies": {
     "express": "3.x",
     "watson-developer-cloud": "*"

--- a/Stage3/watson-talk/package.json
+++ b/Stage3/watson-talk/package.json
@@ -2,9 +2,9 @@
   "name": "hello-world-armada",
   "private": false,
   "version": "0.0.1",
-  "description": "Basic hello world application for Node.js",
+  "description": "Basic Watson Tone relay application for Node.js",
   "dependencies": {
-    "express": "3.4.8",
+    "express": "3.x",
     "watson-developer-cloud": "*"
   }
 }

--- a/Stage3/watson/Dockerfile
+++ b/Stage3/watson/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.9.2
+FROM node:6
 COPY app.js .
 COPY package.json .
 RUN npm install

--- a/Stage3/watson/package.json
+++ b/Stage3/watson/package.json
@@ -2,9 +2,9 @@
   "name": "hello-world-armada",
   "private": false,
   "version": "0.0.1",
-  "description": "Basic hello world application for Node.js",
+  "description": "Basic Watson Tone application for Node.js",
   "dependencies": {
-    "express": "3.4.8",
+    "express": "3.x",
     "watson-developer-cloud": "*"
   }
 }


### PR DESCRIPTION
Using a specified version of the node image resulted in vulnerable packages being in the image.  I switched to using node:6, which is equivalent to the latest release of the node:6 image.  At time of writing that is node:6.10.