### PR TITLE
Switching to using an API Key for login

### DIFF
--- a/bx_login.sh
+++ b/bx_login.sh
@@ -8,14 +8,14 @@ if [ -z $CF_SPACE ]; then
 fi
 
 
-if [ -z "$BLUEMIX_USER" ] || [ -z "$BLUEMIX_PASSWORD" ] || [ -z "$BLUEMIX_ACCOUNT" ] || [ -z "$BLUEMIX_NAMESPACE" ]; then
+if [ -z "$BLUEMIX_API_KEY" || [ -z "$BLUEMIX_NAMESPACE" ]; then
   echo "Define all required environment variables and rerun the stage."
   exit 1
 fi
 echo "Deploy pods"
 
 echo "bx login -a $CF_TARGET_URL"
-bx login -a "$CF_TARGET_URL" -u "$BLUEMIX_USER" -p "$BLUEMIX_PASSWORD" -c "$BLUEMIX_ACCOUNT" -o "$CF_ORG" -s "$CF_SPACE"
+bx login -a "$CF_TARGET_URL" -o "$CF_ORG" -s "$CF_SPACE" --apikey "$BLUEMIX_API_KEY"
 if [ $? -ne 0 ]; then
   echo "Failed to authenticate to Bluemix"
   exit 1


### PR DESCRIPTION
Change to have continuous test login with an API key.  After this is merged, we can delete BLUEMIX_PASSWORD from travis CI, but we should keep the other BLUEMIX_ variables, as that helps with masking results in the build log.