### PR TITLE
Fixing cluster-config command for calicoctl

### DIFF
--- a/Lab 5/README.md
+++ b/Lab 5/README.md
@@ -11,7 +11,7 @@ Before you begin:
 Target the Kubernetes CLI to the cluster. Include the --admin option with the bx cs cluster-config command, which is used to download the certificates and permission files. This download also includes the keys for the Administrator rbac role, which you need to run Calico commands.
 
 
-`bx cs cluster-config <cluster_name>`
+`bx cs cluster-config <cluster_name> --admin`
 
 Note: Calico CLI version 1.4.0 is supported.
 


### PR DESCRIPTION
bx cs cluster-config command needs to use the --admin tag for calioctl, but the example command does not show using that tag.  This can/has confused users.