### PR TITLE
Bhpratt alpine

### DIFF
--- a/Lab 1/Dockerfile
+++ b/Lab 1/Dockerfile
@@ -1,9 +1,8 @@
-FROM registry.ng.bluemix.net/ibmnode
+FROM node:9.4.0-alpine
 COPY app.js .
 COPY package.json .
-RUN npm install
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y upgrade &&\
-  apt-get clean &&\
-  rm -Rf /var/cache/*
+RUN npm install &&\
+    apk update &&\
+    apk upgrade
 EXPOSE  8080
 CMD node app.js

--- a/Lab 2/Dockerfile
+++ b/Lab 2/Dockerfile
@@ -1,9 +1,8 @@
-FROM registry.ng.bluemix.net/ibmnode
+FROM node:9.4.0-alpine
 COPY app.js .
 COPY package.json .
-RUN npm install
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y upgrade &&\
-  apt-get clean &&\
-  rm -Rf /var/cache/*
+RUN npm install &&\
+    apk update &&\
+    apk upgrade
 EXPOSE  8080
 CMD node app.js

--- a/Lab 3/README.md
+++ b/Lab 3/README.md
@@ -73,7 +73,7 @@ Now that the service is bound to the cluster, we want to expose the secret to ou
         - name: service-bind-volume
           secret:
             defaultMode: 420
-            secretName: 2a5baa4b-a52d-4911-9019-69ac01afbb7f-key0 # from the kubectl get secrets command above
+            secretName: binding-tone # from the kubectl get secrets command above
 ```
 
 1. Build the application using the yaml:

--- a/Lab 3/README.md
+++ b/Lab 3/README.md
@@ -73,8 +73,10 @@ Now that the service is bound to the cluster, you want to expose the secret to y
               name: service-bind-volume
       volumes:
         - name: service-bind-volume
-          secret:bhpratt-alpine
-            secretName: binding-tone # from the kubectl get secrets command above
+          secret:
+            defaultMode: 420
+            secretName: binding-tone
+            # from the kubectl get secrets command above
 ```
 
 1. Build the application using the yaml:

--- a/Lab 3/watson-talk/Dockerfile
+++ b/Lab 3/watson-talk/Dockerfile
@@ -1,9 +1,8 @@
-FROM node:6
+FROM node:9.4.0-alpine
 COPY app.js .
 COPY package.json .
-RUN npm install
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y upgrade &&\
-  apt-get clean &&\
-  rm -Rf /var/cache/*
+RUN npm install &&\
+    apk update &&\
+    apk upgrade
 EXPOSE  8080
 CMD node app.js

--- a/Lab 3/watson/Dockerfile
+++ b/Lab 3/watson/Dockerfile
@@ -1,9 +1,8 @@
-FROM node:6
+FROM node:9.4.0-alpine
 COPY app.js .
 COPY package.json .
-RUN npm install
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y upgrade &&\
-  apt-get clean &&\
-  rm -Rf /var/cache/*
-EXPOSE  8081
+RUN npm install &&\
+    apk update &&\
+    apk upgrade
+EXPOSE  8080
 CMD node app.js


### PR DESCRIPTION
ibmnode is being removed from the container registry on Friday 1/19.

upon testing, dockerhub/node is over 500mb memory (which exceeds the free registry quota).

so using alpine, a much slimmed down version. I've tested to confirm that it works in Labs 1, 2, and 3.