### PR TITLE
Updating apiVersion to apps/v1beta1 to properly support post-1.5 Kube

### DIFF
--- a/Lab 1/script/script.md
+++ b/Lab 1/script/script.md
@@ -53,7 +53,7 @@ The elements of a Replication Controller definition
 The strategy for transitioning between deployments
 To create a deployment for a nginx webserver, edit the nginx-deploy.yaml file as
 ```
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   generation: 1

--- a/Lab 2/healthcheck.yml
+++ b/Lab 2/healthcheck.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: hw-demo-deployment

--- a/Lab 3/watson-deployment.yml
+++ b/Lab 3/watson-deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: watson-pod
@@ -38,7 +38,7 @@ spec:
      port: 8081
      nodePort: 30081
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: watson-talk-pod

--- a/Stage1/Stage2/healthcheck.yml
+++ b/Stage1/Stage2/healthcheck.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: hw-demo-deployment

--- a/Stage2/healthcheck.yml
+++ b/Stage2/healthcheck.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: hw-demo-deployment

--- a/Stage3/watson-deployment.yml
+++ b/Stage3/watson-deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+wapiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: watson-pod
@@ -38,7 +38,7 @@ spec:
      port: 8081
      nodePort: 30081
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: watson-talk-pod


### PR DESCRIPTION
Kubernetes versions 1.6 and later should use apps/v1beta1 as the apiVersion for Deployment YAML files.  Failure to do so could break things like affinity/anti-affinity 