### PR TITLE
munge image names

### DIFF
--- a/Lab 1/README.md
+++ b/Lab 1/README.md
@@ -45,9 +45,9 @@ which your cluster has access.
 
    ```bx cr namespace-add <my_namespace>```
    
-6. Build the example Docker image: 
+6. Build the Docker image in this directory with a `v1` tag:
 
-   ```docker build --tag registry.ng.bluemix.net/<my_namespace>/hello-world .```
+   ```docker build --tag registry.ng.bluemix.net/<my_namespace>/hello-world:v1 .```
 
 7. Verify the image is built: 
 
@@ -55,7 +55,7 @@ which your cluster has access.
 
 8. Now push that image up to IBM Cloud Container Registry: 
 
-   ```docker push registry.ng.bluemix.net/<my_namespace>/hello-world```
+   ```docker push registry.ng.bluemix.net/<my_namespace>/hello-world:v1```
 
 9. If you created your cluster at the beginning of this, make sure it's ready for use. 
    1. Run `bx cs clusters` and make sure that your cluster is in "Normal" state.  
@@ -70,7 +70,7 @@ You are now ready to use Kubernetes to deploy the hello-world application.
 
 2. Start by running your image as a deployment: 
 
-   ```kubectl run hello-world --image=registry.ng.bluemix.net/<my_namespace>/hello-world```
+   ```kubectl run hello-world --image=registry.ng.bluemix.net/<my_namespace>/hello-world:v1```
 
    This action will take a bit of time. To check the status of your deployment, you can use `kubectl get pods`.
 

--- a/Lab 2/README.md
+++ b/Lab 2/README.md
@@ -61,7 +61,7 @@ A *replica* is how Kubernetes accomplishes scaling out a deployment. A replica i
 
    You now have 10 replicas of the deployment running in the same pod, providing fault tolerance.
 
-4. To see your changes being rolled out, you can run: `kubectl rollout status deployment/<name-of-deployment>`.
+4. To see your changes being rolled out, you can run: `kubectl rollout status deployment/hello-world`.
 
    The rollout might occur so quickly that the following messages might _not_ display:
 
@@ -106,34 +106,27 @@ A *replica* is how Kubernetes accomplishes scaling out a deployment. A replica i
 
 Kubernetes allows you to use a rollout to update an app deployment with a new Docker image.  This allows you to easily update the running image and also allows you to easily undo a rollout, if a problem is discovered after deployment.
 
-Before you begin, ensure that you have the image tagged with `1` and pushed:
-
-```
-docker build --tag registry.ng.bluemix.net/<namespace>/hello-world:1 .
-
-docker push registry.ng.bluemix.net/<namespace>/hello-world:1
-```
+In the previous lab, we created an image with a `v1` tag. Let's make a `v2` tag with new content. This lab also contains a `Dockerfile`. Let's build and push it up to our image registry.
 
 To update and roll back:
-1. Make a change to your code and build a new docker image with a new tag:
+1. Build the new docker image with a different `v2` tag:
 
-   ```docker build --tag registry.ng.bluemix.net/<namespace>/hello-world:2 .```
+   ```docker build --tag registry.ng.bluemix.net/<my_namespace>/hello-world:v2 .```
 
 2. Push the image to the IBM Cloud Container Registry:
 
-   ```docker push registry.ng.bluemix.net/<namespace>/hello-world:2```
+   ```docker push registry.ng.bluemix.net/<my_namespace>/hello-world:v2```
 
-3. Using `kubectl`, you can now update your deployment to use the latest image.  
+3. Using `kubectl`, you can now update your deployment to use the
+   latest image. `kubectl` allows you to change details about existing
+   resources with the `set` subcommand. We can use it to change the
+   image being used.
 
-   There are two ways to do this:
-   * You can edit the yaml again using `kubectl edit deployment/<name-of-deployment>`
-   * You can just specify a new image using a single command. Using a single command is especially useful when writing deployment automation. To specify the new image, run the following:
+    ```kubectl set image deployment/hello-world hello-world=registry.ng.bluemix.net/<namespace>/hello-world:v2```
 
-      ```kubectl set image deployment/hello-world hello-world=registry.ng.bluemix.net/<namespace>/hello-world:2```
+    Note that a pod could have multiple containers, in which case each container will have its own name.  Multiple containers can be updated at the same time.  ([More information](https://kubernetes.io/docs/user-guide/kubectl/kubectl_set_image/).)
 
-      Note that a deployment could have multiple containers, in which case each container will have its own name.  Multiple containers can be updated at the same time.  ([More information](https://kubernetes.io/docs/user-guide/kubectl/kubectl_set_image/).)
-
-4. Run `kubectl rollout status deployment/<name-of-deployment>` or `kubectl get replicasets` to check the status of the rollout. The rollout might occur so quickly that the following messages might _not_ display:
+4. Run `kubectl rollout status deployment/hello-world` or `kubectl get replicasets` to check the status of the rollout. The rollout might occur so quickly that the following messages might _not_ display:
 
    ```
    => kubectl rollout status deployment/hello-world
@@ -205,7 +198,7 @@ In this example, we have defined a HTTP liveness probe to check health of the co
    1. Update the details for the image in your private registry namespace:
 
       ```
-      image: "registry.<region>.bluemix.net/<namespace>/hello-world:2"
+      image: "registry.<region>.bluemix.net/<namespace>/hello-world:v2"
       ```
 
    2. Note the HTTP liveness probe that checks the health of the container every five seconds.

--- a/Lab 2/healthcheck.yml
+++ b/Lab 2/healthcheck.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: hw-demo-container
-          image: "registry.ng.bluemix.net/<namespace>/hello-world:2"
+          image: "registry.ng.bluemix.net/<namespace>/hello-world:v2"
           imagePullPolicy: Always
           livenessProbe:
             httpGet:

--- a/Lab 3/README.md
+++ b/Lab 3/README.md
@@ -14,7 +14,7 @@ In this lab, set up an application to leverage the Watson Tone Analyzer service.
    ```docker push registry.ng.bluemix.net/<namespace>/watson```
 
    **Tip:** If you run out of registry space, clean up the previous lab's images with this example command: 
-      ```bx cr image-rm registry.ng.bluemix.net/<namespace>/hello-world:2```
+      ```bx cr image-rm registry.ng.bluemix.net/<namespace>/hello-world:v2```
 
 4. Build the `watson-talk` image:
    ```docker build -t registry.ng.bluemix.net/<namespace>/watson-talk ./watson-talk```


### PR DESCRIPTION
Move 'v1' tag to lab1. Establish more continuity between labs.

One way to do things. Commentary about using 'kubectl set'.

Kind of intrusive, but there's no reason not to establish the `v1` tag and use it earlier.

also more using of 'deployment hello-world' and `my_namespace`

@kennjason @duglin 
