### PR TITLE
changing v1 and v2 to 1 and 2

### DIFF
--- a/Lab 1/README.md
+++ b/Lab 1/README.md
@@ -45,9 +45,9 @@ which your cluster has access.
 
    ```bx cr namespace-add <my_namespace>```
    
-6. Build the Docker image in this directory with a `v1` tag:
+6. Build the Docker image in this directory with a version `1` tag:
 
-   ```docker build --tag registry.ng.bluemix.net/<my_namespace>/hello-world:v1 .```
+   ```docker build --tag registry.ng.bluemix.net/<my_namespace>/hello-world:1 .```
 
 7. Verify the image is built: 
 
@@ -55,7 +55,7 @@ which your cluster has access.
 
 8. Now push that image up to IBM Cloud Container Registry: 
 
-   ```docker push registry.ng.bluemix.net/<my_namespace>/hello-world:v1```
+   ```docker push registry.ng.bluemix.net/<my_namespace>/hello-world:1```
 
 9. If you created your cluster at the beginning of this, make sure it's ready for use. 
    1. Run `bx cs clusters` and make sure that your cluster is in "Normal" state.  
@@ -70,7 +70,7 @@ You are now ready to use Kubernetes to deploy the hello-world application.
 
 2. Start by running your image as a deployment: 
 
-   ```kubectl run hello-world --image=registry.ng.bluemix.net/<my_namespace>/hello-world:v1```
+   ```kubectl run hello-world --image=registry.ng.bluemix.net/<my_namespace>/hello-world:1```
 
    This action will take a bit of time. To check the status of your deployment, you can use `kubectl get pods`.
 

--- a/Lab 1/README.md
+++ b/Lab 1/README.md
@@ -45,7 +45,7 @@ which your cluster has access.
 
    ```bx cr namespace-add <my_namespace>```
    
-6. Build the Docker image in this directory with a version `1` tag:
+6. Build the Docker image in this directory with a `1` tag:
 
    ```docker build --tag registry.ng.bluemix.net/<my_namespace>/hello-world:1 .```
 

--- a/Lab 2/README.md
+++ b/Lab 2/README.md
@@ -71,7 +71,7 @@ A *replica* is how Kubernetes accomplishes scaling out a deployment. A replica i
 
 Kubernetes allows you to use a rollout to update an app deployment with a new Docker image.  This allows you to easily update the running image and also allows you to easily undo a rollout, if a problem is discovered after deployment.
 
-In the previous lab, we created an image with a version `1` tag. Let's make a version `2` tag with new content. This lab also contains a `Dockerfile`. Let's build and push it up to our image registry.
+In the previous lab, we created an image with a `1` tag. Let's make a version of the image that includes new content and use a `2` tag. This lab also contains a `Dockerfile`. Let's build and push it up to our image registry.
 
 To update and roll back:
 1. Build the new docker image with a `2` tag:

--- a/Lab 2/README.md
+++ b/Lab 2/README.md
@@ -71,23 +71,23 @@ A *replica* is how Kubernetes accomplishes scaling out a deployment. A replica i
 
 Kubernetes allows you to use a rollout to update an app deployment with a new Docker image.  This allows you to easily update the running image and also allows you to easily undo a rollout, if a problem is discovered after deployment.
 
-In the previous lab, we created an image with a `v1` tag. Let's make a `v2` tag with new content. This lab also contains a `Dockerfile`. Let's build and push it up to our image registry.
+In the previous lab, we created an image with a version `1` tag. Let's make a version `2` tag with new content. This lab also contains a `Dockerfile`. Let's build and push it up to our image registry.
 
 To update and roll back:
-1. Build the new docker image with a different `v2` tag:
+1. Build the new docker image with a `2` tag:
 
-   ```docker build --tag registry.ng.bluemix.net/<my_namespace>/hello-world:v2 .```
+   ```docker build --tag registry.ng.bluemix.net/<my_namespace>/hello-world:2 .```
 
 2. Push the image to the IBM Cloud Container Registry:
 
-   ```docker push registry.ng.bluemix.net/<my_namespace>/hello-world:v2```
+   ```docker push registry.ng.bluemix.net/<my_namespace>/hello-world:2```
 
 3. Using `kubectl`, you can now update your deployment to use the
    latest image. `kubectl` allows you to change details about existing
    resources with the `set` subcommand. We can use it to change the
    image being used.
 
-    ```kubectl set image deployment/hello-world hello-world=registry.ng.bluemix.net/<namespace>/hello-world:v2```
+    ```kubectl set image deployment/hello-world hello-world=registry.ng.bluemix.net/<namespace>/hello-world:2```
 
     Note that a pod could have multiple containers, in which case each container will have its own name.  Multiple containers can be updated at the same time.  ([More information](https://kubernetes.io/docs/user-guide/kubectl/kubectl_set_image/).)
 
@@ -163,7 +163,7 @@ In this example, we have defined a HTTP liveness probe to check health of the co
    1. Update the details for the image in your private registry namespace:
 
       ```
-      image: "registry.<region>.bluemix.net/<namespace>/hello-world:v2"
+      image: "registry.<region>.bluemix.net/<namespace>/hello-world:2"
       ```
 
    2. Note the HTTP liveness probe that checks the health of the container every five seconds.

--- a/Lab 2/healthcheck.yml
+++ b/Lab 2/healthcheck.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: hw-demo-container
-          image: "registry.ng.bluemix.net/<namespace>/hello-world:v2"
+          image: "registry.ng.bluemix.net/<namespace>/hello-world:2"
           imagePullPolicy: Always
           livenessProbe:
             httpGet:

--- a/Lab 3/README.md
+++ b/Lab 3/README.md
@@ -14,7 +14,7 @@ In this lab, set up an application to leverage the Watson Tone Analyzer service.
    ```docker push registry.ng.bluemix.net/<namespace>/watson```
 
    **Tip:** If you run out of registry space, clean up the previous lab's images with this example command: 
-      ```bx cr image-rm registry.ng.bluemix.net/<namespace>/hello-world:v2```
+      ```bx cr image-rm registry.ng.bluemix.net/<namespace>/hello-world:2```
 
 4. Build the `watson-talk` image:
    ```docker build -t registry.ng.bluemix.net/<namespace>/watson-talk ./watson-talk```


### PR DESCRIPTION
Changing to `:1` and `:2` because I believe it's more standard. Also, the dw course uses `:1` and `:2` and we need our yaml to match what the customer is expecting to be pulled.