### PR TITLE
fixed api versions and added matchLabels

### DIFF
--- a/Lab 1/script/script.md
+++ b/Lab 1/script/script.md
@@ -53,7 +53,7 @@ The elements of a Replication Controller definition
 The strategy for transitioning between deployments
 To create a deployment for a nginx webserver, edit the nginx-deploy.yaml file as
 ```
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   generation: 1

--- a/Lab 2/healthcheck.yml
+++ b/Lab 2/healthcheck.yml
@@ -1,8 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hw-demo-deployment
 spec:
+  selector:
+    matchLabels:
+      run: hw-demo-health
+      test: hello-world-demo
   replicas: 3
   template:
     metadata:

--- a/Lab 3/watson-deployment.yml
+++ b/Lab 3/watson-deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/apps/v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: watson-pod

--- a/Lab 3/watson-deployment.yml
+++ b/Lab 3/watson-deployment.yml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/apps/v1
 kind: Deployment
 metadata:
   name: watson-pod
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      run: watson-demo
   template:
     metadata:
       name: watson-pod
@@ -38,12 +41,15 @@ spec:
      port: 8081
      nodePort: 30081
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: watson-talk-pod
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      run: watson-talk-demo
   template:
     metadata:
       name: watson-talk-pod

--- a/Lab 4/README.md
+++ b/Lab 4/README.md
@@ -181,7 +181,7 @@ The API for federated deployment is compatible with the API for traditional Kube
    This example will deploy a simple nginx image to your federated cluster. The configuration file is shown below:
 
    ```yml
-   apiVersion: apps/v1beta2
+   apiVersion: apps/v1
    kind: Deployment
    metadata:
      name: nginx-deployment

--- a/Lab 5/README.md
+++ b/Lab 5/README.md
@@ -259,7 +259,7 @@ $ calicoctl get wep --workload advanced-policy-demo.nginx-701339712-x1uqe -o yam
 
    ```
    kind: NetworkPolicy
-   apiVersion: extensions/v1beta1
+   apiVersion: networking.k8s.io/v1
    metadata:
      name: access-nginx
      namespace: advanced-policy-demo


### PR DESCRIPTION
per https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/, updated deployment and network policy apis. also added `matchLabels` field where appropriate